### PR TITLE
External links: `rel` and arrow icon

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -91,7 +91,8 @@ module.exports = function(eleventyConfig) {
 
     if (href && !href.match(externalLinkRegExp)) {
       tokens[idx].attrPush([ 'rel', 'noopener noreferrer' ])
-      console.log(`Added rel="noopener noreferrer" to ${href}`)
+      tokens[idx].attrPush([ 'class', 'external-link' ])
+      console.log(`Added \`rel="noopener noreferrer" class="external-link"\` to ${href}`)
     }
   }).use(markdownItAnchor, {
     permalink: markdownItAnchor.permalink.ariaHidden({

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,19 @@ const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
 const pluginNavigation = require("@11ty/eleventy-navigation");
 const markdownIt = require("markdown-it");
 const markdownItAnchor = require("markdown-it-anchor");
+const mdIterator = require('markdown-it-for-inline');
 const shikiTwoslash = require("eleventy-plugin-shiki-twoslash");
+
+let metadata = null;
+
+fs.readFile("./_data/metadata.json", 'utf8', (err, data) => {
+  if (err) {
+    console.log("Error reading metadata in .eleventy.js");
+    console.warn(err);
+  } else {
+    metadata = JSON.parse(data);
+  }
+});
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addWatchTarget('tailwind.config.js')
@@ -73,6 +85,14 @@ module.exports = function(eleventyConfig) {
     html: true,
     breaks: true,
     linkify: true
+  }).use(mdIterator, 'url_new_win', 'link_open', function (tokens, idx) {
+    const [_attrName, href] = tokens[idx].attrs.find(attr => attr[0] === 'href')
+    const externalLinkRegExp = new RegExp(`^(\/|#|${metadata.url})`)
+
+    if (href && !href.match(externalLinkRegExp)) {
+      tokens[idx].attrPush([ 'rel', 'noopener noreferrer' ])
+      console.log(`Added rel="noopener noreferrer" to ${href}`)
+    }
   }).use(markdownItAnchor, {
     permalink: markdownItAnchor.permalink.ariaHidden({
       placement: "before",

--- a/css/index.css
+++ b/css/index.css
@@ -34,6 +34,10 @@
 }
 
 @layer components {
+  .external-link::after {
+    content: '\279A';
+  }
+  
   .groundhog {
     @apply absolute bg-center bg-contain bg-groundhog inset-10 sm:inset-12 md:inset-20 lg:inset-24 xl:inset-32 p-5 sm:p-10 md:p-20 lg:p-32 xl:p-40;
   }

--- a/package.yaml
+++ b/package.yaml
@@ -43,6 +43,7 @@ devDependencies:
   luxon: ^2.3.0
   markdown-it: ^12.3.2
   markdown-it-anchor: ^8.4.1
+  markdown-it-for-inline: ^0.1.1
   postcss: ^8.4.5
   tailwindcss: ^3.0.18
   yaml: ^1.10.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ specifiers:
   luxon: ^2.3.0
   markdown-it: ^12.3.2
   markdown-it-anchor: ^8.4.1
+  markdown-it-for-inline: ^0.1.1
   postcss: ^8.4.5
   tailwindcss: ^3.0.18
   yaml: ^1.10.2
@@ -42,6 +43,7 @@ devDependencies:
   luxon: 2.3.0
   markdown-it: 12.3.2
   markdown-it-anchor: 8.4.1_d643ca6eb40ae68ab966a77bead78073
+  markdown-it-for-inline: 0.1.1
   postcss: 8.4.5
   tailwindcss: 3.0.18_ef48b3b8837f8a23677bffe8f9cd866d
   yaml: 1.10.2
@@ -3573,6 +3575,10 @@ packages:
     dependencies:
       '@types/markdown-it': 12.2.3
       markdown-it: 12.3.2
+    dev: true
+
+  /markdown-it-for-inline/0.1.1:
+    resolution: {integrity: sha1-Q18jFvW15o4UUM+iJC8rjVmtx18=}
     dev: true
 
   /markdown-it/12.3.2:


### PR DESCRIPTION
- All external links get `rel="noopener noreferrer" class="external-link"`
- `.external-link` gets an arrow

Learned about the markdown-it-for-inline solution from https://franknoirot.co/posts/external-links-markdown-plugin/